### PR TITLE
JY-6253 pass access token as header

### DIFF
--- a/src/Provider/Zoom.php
+++ b/src/Provider/Zoom.php
@@ -96,20 +96,7 @@ class Zoom extends AbstractProvider
      */
     public function getAuthenticatedRequest($method, $url, $token, array $options = [])
     {
-        $parsedUrl = parse_url($url);
-        $queryString = array();
-
-        if (isset($parsedUrl['query'])) {
-            parse_str($parsedUrl['query'], $queryString);
-        }
-
-        if (!isset($queryString['access_token'])) {
-            $queryString['access_token'] = (string) $token;
-        }
-
-        $url = http_build_url($url, [
-            'query' => http_build_query($queryString),
-        ]);
+        $options['headers']['Authorization'] = 'Bearer ' . $token;
 
         return $this->createRequest($method, $url, null, $options);
     }


### PR DESCRIPTION
Zoom API no longer accepts access_token via query string. We need. to pass it as Authorisation header